### PR TITLE
add cares pdb files

### DIFF
--- a/win/nuget/c-ares/Roaster.c-ares.v141.dyn.x64.targets
+++ b/win/nuget/c-ares/Roaster.c-ares.v141.dyn.x64.targets
@@ -14,12 +14,24 @@
       <Link>acountry.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/acountry.pdb">
+      <Link>acountry.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/adig.exe">
       <Link>adig.exe</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/adig.pdb">
+      <Link>adig.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/ahost.exe">
       <Link>ahost.exe</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/ahost.pdb">
+      <Link>ahost.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/cares.dll">
@@ -28,18 +40,6 @@
     </Content>
     <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/cares.pdb">
       <Link>cares.pdb</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/ahost.pdb">
-      <Link>ahost.pdb</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/adig.pdb">
-      <Link>adig.pdb</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/acountry.pdb">
-      <Link>acountry.pdb</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/win/nuget/c-ares/Roaster.c-ares.v141.dyn.x64.targets
+++ b/win/nuget/c-ares/Roaster.c-ares.v141.dyn.x64.targets
@@ -26,5 +26,21 @@
       <Link>cares.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/cares.pdb">
+      <Link>cares.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/ahost.pdb">
+      <Link>ahost.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/adig.pdb">
+      <Link>adig.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="$(MSBuildThisFileDirectory)/../lib/native/lib/Release/acountry.pdb">
+      <Link>acountry.pdb</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Our static analysis tool is complaining about not being able to find cares.pdb file and therefore results in a build failure, to fix that, adding cares pdb files to its Roaster nuget package.

![image](https://user-images.githubusercontent.com/25216338/58660839-3f1fad00-82db-11e9-8f92-4e0498eeaab4.png)