### PR TITLE
Cherry-pick fix of ORT CUDA test hang issue

### DIFF
--- a/pkgs/ort.sh
+++ b/pkgs/ort.sh
@@ -19,10 +19,11 @@
     cd onnxruntime
 
     # Known issues:
-    #  - CUDA test hang without GPU.
-    #    https://github.com/microsoft/onnxruntime/issues/4656
+    #   - CUDA test hang without GPU.
+    #     https://github.com/microsoft/onnxruntime/issues/4656
     git fetch origin master
     git cherry-pick 0978d2b
+    git cherry-pick 7250562
 
     git remote add patch https://github.com/xkszltl/onnxruntime.git
 

--- a/pkgs/ort.sh
+++ b/pkgs/ort.sh
@@ -18,6 +18,12 @@
     until git clone -b "$GIT_TAG" "$GIT_REPO"; do echo 'Retrying'; done
     cd onnxruntime
 
+    # Known issues:
+    #  - CUDA test hang without GPU.
+    #    https://github.com/microsoft/onnxruntime/issues/4656
+    git fetch origin master
+    git cherry-pick 0978d2b
+
     git remote add patch https://github.com/xkszltl/onnxruntime.git
 
     PATCHES=""

--- a/win/pkgs/ort.ps1
+++ b/win/pkgs/ort.ps1
@@ -45,6 +45,12 @@ $use_bat = $false
 # Patch
 # ================================================================================
 
+# Known issues:
+#  - CUDA test hang without GPU.
+#    https://github.com/microsoft/onnxruntime/issues/4656
+git fetch origin master
+git cherry-pick 0978d2b
+
 git remote add patch https://github.com/xkszltl/onnxruntime.git
 git fetch patch
 

--- a/win/pkgs/ort.ps1
+++ b/win/pkgs/ort.ps1
@@ -46,10 +46,11 @@ $use_bat = $false
 # ================================================================================
 
 # Known issues:
-#  - CUDA test hang without GPU.
-#    https://github.com/microsoft/onnxruntime/issues/4656
+#   - CUDA test hang without GPU.
+#     https://github.com/microsoft/onnxruntime/issues/4656
 git fetch origin master
 git cherry-pick 0978d2b
+git cherry-pick 7250562
 
 git remote add patch https://github.com/xkszltl/onnxruntime.git
 git fetch patch


### PR DESCRIPTION
Cherry-pick fix of ORT CUDA test hang issue.

See:
- https://github.com/microsoft/onnxruntime/pull/6138
- https://github.com/microsoft/onnxruntime/issues/4656