### PR TITLE
Fix some Win CI build issues

### DIFF
--- a/azure-pipelines.windows.yml
+++ b/azure-pipelines.windows.yml
@@ -43,6 +43,8 @@ stages:
     - job: env
       steps:
       - powershell: |
+          ${Env:PATH}=[System.Environment]::GetEnvironmentVariable("PATH","Machine")
+
           cmake --version
           nvcc -V
           python -V

--- a/azure-pipelines.windows.yml
+++ b/azure-pipelines.windows.yml
@@ -139,7 +139,7 @@ stages:
 
     - job: opencv
       dependsOn: grpc
-      timeoutInMinutes: "120"
+      timeoutInMinutes: "720"
       steps:
       - template: azure-pipelines/build_stage.windows.yml
 
@@ -155,6 +155,6 @@ stages:
 
     - job: ort
       dependsOn: onnx
-      timeoutInMinutes: "240"
+      timeoutInMinutes: "720"
       steps:
       - template: azure-pipelines/build_stage.windows.yml

--- a/azure-pipelines.windows.yml
+++ b/azure-pipelines.windows.yml
@@ -139,6 +139,7 @@ stages:
 
     - job: opencv
       dependsOn: grpc
+      timeoutInMinutes: "120"
       steps:
       - template: azure-pipelines/build_stage.windows.yml
 
@@ -154,6 +155,6 @@ stages:
 
     - job: ort
       dependsOn: onnx
-      timeoutInMinutes: "1440"
+      timeoutInMinutes: "240"
       steps:
       - template: azure-pipelines/build_stage.windows.yml

--- a/win/pkgs/cmake.ps1
+++ b/win/pkgs/cmake.ps1
@@ -21,7 +21,7 @@ if (Test-Path "$root")
 $latest_ver = 'v' + $($(git ls-remote --tags "$repo") -match '.*refs/tags/v[0-9\.]*$' -replace '.*refs/tags/v','' | sort {[Version]$_})[-1]
 
 $cmake_url = "${Env:GIT_MIRROR_GITHUB}/Kitware/CMake/releases/download/$latest_ver"
-$cmake_name = "cmake-$($latest_ver -replace '^v','')-windows-x86_x64.msi"
+$cmake_name = "cmake-$($latest_ver -replace '^v','')-windows-x86_64.msi"
 if (-not $(Test-Path "$cmake_name"))
 {
     $uri = "$cmake_url/$cmake_name"

--- a/win/pkgs/cmake.ps1
+++ b/win/pkgs/cmake.ps1
@@ -21,7 +21,7 @@ if (Test-Path "$root")
 $latest_ver = 'v' + $($(git ls-remote --tags "$repo") -match '.*refs/tags/v[0-9\.]*$' -replace '.*refs/tags/v','' | sort {[Version]$_})[-1]
 
 $cmake_url = "${Env:GIT_MIRROR_GITHUB}/Kitware/CMake/releases/download/$latest_ver"
-$cmake_name = "cmake-$($latest_ver -replace '^v','')-win64-x64.msi"
+$cmake_name = "cmake-$($latest_ver -replace '^v','')-windows-x86_x64.msi"
 if (-not $(Test-Path "$cmake_name"))
 {
     $uri = "$cmake_url/$cmake_name"

--- a/win/pkgs/cuda.ps1
+++ b/win/pkgs/cuda.ps1
@@ -31,7 +31,7 @@ ${Env:CUDA_PATH}=[System.Environment]::GetEnvironmentVariable("CUDA_PATH","Machi
 if (${Env:VSCMD_VER} -ne $null)
 {
     $vs_where = "${Env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe"
-    $vs_home = & $vs_where -latest -products 'Microsoft.VisualStudio.Product.BuildTools' -property installationPath
+    $vs_home = & $vs_where -all -latest -products 'Microsoft.VisualStudio.Product.BuildTools' -property installationPath
     if ($vs_home)
     {
         $cuda_vsext_dir = "${Env:CUDA_PATH}/extras/visual_studio_integration/MSBuildExtensions"

--- a/win/pkgs/env/toolchain.ps1
+++ b/win/pkgs/env/toolchain.ps1
@@ -188,7 +188,11 @@ if (-Not $Env:ROASTER_TOOLCHAIN_COMMITED)
             exit 1
         }
 
-        Invoke-Expression $($(cmd /c "`"${VS_HOME}/VC/Auxiliary/Build/vcvarsall.bat`" x64 10.0.16299.0 & set") -Match '^.+=' -Replace '^','${Env:' -Replace '=','}="' -Replace '$','"' | Out-String)
+        foreach ($env in $(cmd /c "`"${VS_HOME}/VC/Auxiliary/Build/vcvarsall.bat`" x64 10.0.16299.0 & set") -Match '^.+=')
+        {
+            $name, $value = $env.Split("=", 2)
+            [Environment]::SetEnvironmentVariable($name, $value)
+        }
 
         if ((${Env:VCToolsVersion} -eq $null) -or -not ${Env:VCToolsVersion}.StartsWith("14.2"))
         {

--- a/win/pkgs/env/toolchain.ps1
+++ b/win/pkgs/env/toolchain.ps1
@@ -3,10 +3,16 @@
 if (-Not $Env:ROASTER_TOOLCHAIN_COMMITED)
 {
     # ================================================================================
-    # Restore system default PATH, including potential updates.
+    # Restore environment variables, including potential updates.
     # ================================================================================
-
-    ${Env:PATH}=[System.Environment]::GetEnvironmentVariable("PATH","Machine")
+    foreach ($env in [System.Environment]::GetEnvironmentVariables("Machine").GetEnumerator())
+    {
+        if ($env.Name -eq "PATH" -or $env.Name.StartsWith("CUDA"))
+        {
+            Write-Host "Restore environment var $($env.Name) to $($env.Value)"
+            [Environment]::SetEnvironmentVariable($env.Name, $env.Value)
+        }
+    }
 
     # ================================================================================
     # Path longer than 260 may resolve to some obscure errors.

--- a/win/pkgs/tensorrt.ps1
+++ b/win/pkgs/tensorrt.ps1
@@ -42,7 +42,7 @@ Move-Item -Force "${trt_name}.extracting.d/TensorRT-*" "tensorrt"
 rm -Force -Recurse "${trt_name}.extracting.d"
 
 rm -Force -Recurse -ErrorAction SilentlyContinue -WarningAction SilentlyContinue "${Env:ProgramFiles}/tensorrt"
-Move-Item -Force "tensorrt" "${Env:ProgramFiles}/tensorrt"
+Copy-Item -Recurse -Force "tensorrt" "${Env:ProgramFiles}/tensorrt"
 Get-ChildItem "${Env:ProgramFiles}/tensorrt" -Filter *.dll -Recurse | Foreach-Object { New-Item -Force -ItemType SymbolicLink -Path "${Env:SystemRoot}\System32\$_" -Value $_.FullName }
 
 popd

--- a/win/pkgs/tensorrt.ps1
+++ b/win/pkgs/tensorrt.ps1
@@ -42,7 +42,7 @@ Move-Item -Force "${trt_name}.extracting.d/TensorRT-*" "tensorrt"
 rm -Force -Recurse "${trt_name}.extracting.d"
 
 rm -Force -Recurse -ErrorAction SilentlyContinue -WarningAction SilentlyContinue "${Env:ProgramFiles}/tensorrt"
-Copy-Item -Recurse -Force "tensorrt" "${Env:ProgramFiles}/tensorrt"
+Move-Item -Force "tensorrt" "${Env:ProgramFiles}/tensorrt"
 Get-ChildItem "${Env:ProgramFiles}/tensorrt" -Filter *.dll -Recurse | Foreach-Object { New-Item -Force -ItemType SymbolicLink -Path "${Env:SystemRoot}\System32\$_" -Value $_.FullName }
 
 popd

--- a/win/pkgs/vsbuildtools.ps1
+++ b/win/pkgs/vsbuildtools.ps1
@@ -5,7 +5,7 @@ $ErrorActionPreference="Stop"
 $vs_where = "${Env:ProgramFiles(x86)}/Microsoft Visual Studio/Installer/vswhere.exe"
 if (Test-Path $vs_where)
 {
-    $vs_home = & $vs_where -latest -products * -property installationPath
+    $vs_home = & $vs_where -all -latest -products * -property installationPath
     if ($vs_home)
     {
         Write-Host "Found existing VS installation under `"$vs_home`". Skip installation."
@@ -19,6 +19,7 @@ Invoke-WebRequest -Uri "https://aka.ms/vs/16/release/vs_buildtools.exe" -OutFile
     --nocache                                                           `
     --norestart                                                         `
     --wait                                                              `
+    --quiet                                                             `
     --add "Microsoft.VisualStudio.Workload.VCTools;includeRecommended"  `
     --add "Microsoft.VisualStudio.Component.Windows10SDK.16299" | Out-Null
 


### PR DESCRIPTION
Migrate VSTS selfhost agents to VMSS. Fix some issues during CI build:
- Fix `vswhere` query args by appending `-all` to include product `vsbuildtools`;
- Restore more ENV variables in toolchain.ps1, for example, `CUDA*`;
- Adjust build timeout for opencv and ort build;
- Correct cmake download link.